### PR TITLE
Add support for 3-arg subtraction

### DIFF
--- a/src/calc_test.py
+++ b/src/calc_test.py
@@ -11,6 +11,10 @@ class TestStringMethods(unittest.TestCase):
         # Make sure 4 - 3 = 1
         self.assertEqual(sub(4, 3), 1, 'subtracting three from four')
 
+    def test_sub_3arg(self):
+        # Make sure 4 - 3 - 7 = -6
+        self.assertEqual(sub(4, 3, -7), 1, 'subtracting three and 7 from four')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
We promised our customers this would be possible

```py
sub(3, 4, 2) # -3
```

Apparently we never finished this, so here's the fix

## Required Steps
- [ ] Check with the product owner
- [ ] Write tests
- [ ] Update docs
- [ ] Get code review


## Testing Done
