### PR TITLE
Add support for 3-arg addition

### DIFF
--- a/src/calc.py
+++ b/src/calc.py
@@ -1,12 +1,13 @@
-def add(a, b):
+def add(a, b, c = 0):
     """
     Add some numbers together
 
     ```py
     add(2, 3) # 5
+    add(2, 3, 4) # 9
     ```
     """
-    return a + b
+    return a + b + c
 
 def sub(a, b):
     """

--- a/src/calc.py
+++ b/src/calc.py
@@ -1,4 +1,4 @@
-def add(a, b, c = 0):
+def add(a, b, third_operand = 0):
     """
     Add some numbers together
 
@@ -7,7 +7,7 @@ def add(a, b, c = 0):
     add(2, 3, 4) # 9
     ```
     """
-    return a + b + c
+    return a + b + third_operand
 
 def sub(a, b):
     """

--- a/src/calc_test.py
+++ b/src/calc_test.py
@@ -7,6 +7,9 @@ class TestStringMethods(unittest.TestCase):
         # Make sure 3 + 4 = 7
         self.assertEqual(add(3, 4), 7, 'adding three and four')
 
+    def test_add_3arg(self):
+        self.assertEqual(add(3, 5, 2), 10, 'adding three, five and two')
+
     def test_sub_2arg(self):
         # Make sure 4 - 3 = 1
         self.assertEqual(sub(4, 3), 1, 'subtracting three from four')


### PR DESCRIPTION
We promised our customers that we'd initially support

```py
add(3, 4, 5) # 12
```

Our first release missed this. This bugfix will deliver the promised feature