### PR TITLE
BUGFIX: 3-arg addition was not implemeneted

### DIFF
--- a/src/calc_test.py
+++ b/src/calc_test.py
@@ -10,13 +10,6 @@ class TestStringMethods(unittest.TestCase):
     def test_add_3arg(self):
         self.assertEqual(add(3, 5, 2), 10, 'adding three, five and two')
 
-    def test_add_zeroes(self):
-        self.assertEqual(add(0, 0, 0), 0 , 'adding zeroes together is zero')
-
-    def test_sub_2arg(self):
-        # Make sure 4 - 3 = 1
-        self.assertEqual(sub(4, 3), 1, 'subtracting three from four')
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The following change allows use of add like

```py

add(4, 5, 1) #10
```

We promised customer that we would have this in our
initial release, so this is a bug, not an enhancement.
