### PR TITLE
BUGFIX: 3-arg subtraction was not implemented

### DIFF
--- a/src/calc_test.py
+++ b/src/calc_test.py
@@ -17,6 +17,9 @@ class TestStringMethods(unittest.TestCase):
         # Make sure 4 - 3 = 1
         self.assertEqual(sub(4, 3), 1, 'subtracting three from four')
 
+    def test_sub_3arg(self):
+        # Make sure 4 - 2- 1 = 1
+        self.assertEqual(sub(4, 2, 1), 1, 'subtracting two and one from four')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Following change allows 3 args sub
```py
   sub(4, 2, 1) #1
```

Should have been part of an initial release.

## Required Steps
- [ ] Check with the product owner
- [ ] Write tests
- [ ] Update docs
- [ ] Get code review


## Testing Done
