### PR TITLE
BUGFIX: 3-arg subraction was not implemented

### DIFF
--- a/src/calc_test.py
+++ b/src/calc_test.py
@@ -1,4 +1,4 @@
-import unittest
+iimport unittest
 from calc import add, sub
 
 class TestStringMethods(unittest.TestCase):
@@ -16,7 +16,9 @@ class TestStringMethods(unittest.TestCase):
     def test_sub_2arg(self):
         # Make sure 4 - 3 = 1
         self.assertEqual(sub(4, 3), 1, 'subtracting three from four')
-
+    
+    def test_sub_3arg(self):
+        self.asserEqual(sub(4,3,1),0, 'subtracting three and one from four')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The following change allows use of sub like

```py

sub(5,4,1) #0
```

## Required Steps
- [ ] Check with the product owner
- [ ] Write tests
- [ ] Update docs
- [ ] Get code review


## Testing Done
