### PR TITLE
BUGFIX: 3-arg subtraction was not implemented

### DIFF
--- a/src/calc.py
+++ b/src/calc.py
@@ -5,6 +5,7 @@ def add(a, b, third_operand = 0):
     ```py
     add(2, 3) # 5
     add(2, 3, 4) # 9
+    hello
     ```
     """
     return a + b + third_operand

--- a/src/calc.py
+++ b/src/calc.py
@@ -5,7 +5,6 @@ def add(a, b, third_operand = 0):
     ```py
     add(2, 3) # 5
     add(2, 3, 4) # 9
-    hello
     ```
     """
     return a + b + third_operand

--- a/src/calc_test.py
+++ b/src/calc_test.py
@@ -17,6 +17,8 @@ class TestStringMethods(unittest.TestCase):
         # Make sure 4 - 3 = 1
         self.assertEqual(sub(4, 3), 1, 'subtracting three from four')
 
+    def test_sub_3arg(self):
+        self.assertEqual(sub(4, 3, 1), 0, 'subtracting three from one from four')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The following change  allows use of sub like

```py
  sub(5, 4, 1) #0
```

  We promised customers that we would have this in our 
  initial release, so this is a bug, not an enhancement

