### PR TITLE
BUGFIX: 3-arg subtraction was not implemented.

### DIFF
--- a/src/calc.py
+++ b/src/calc.py
@@ -9,12 +9,13 @@ def add(a, b, third_operand = 0):
     """
     return a + b + third_operand
 
-def sub(a, b):
+def sub(a, b, c = 0):
     """
     Subtract some numbers
 
     ```py
     sub(8, 3) # 5
+    sub(8, 3, 10) # -5
     ```
     """
-    return a - b
+    return a - b -c

--- a/src/calc.py
+++ b/src/calc.py
@@ -9,7 +9,7 @@ def add(a, b, third_operand = 0):
     """
     return a + b + third_operand
 
-def sub(a, b, c = 0):
+def sub(a, b, x = 0):
     """
     Subtract some numbers
 
@@ -18,4 +18,4 @@ def sub(a, b, c = 0):
     sub(8, 3, 10) # -5
     ```
     """
-    return a - b -c
+    return a - b - x

--- a/src/calc_test.py
+++ b/src/calc_test.py
@@ -17,6 +17,8 @@ class TestStringMethods(unittest.TestCase):
         # Make sure 4 - 3 = 1
         self.assertEqual(sub(4, 3), 1, 'subtracting three from four')
 
+    def test_sub_3arg(self):
+        self.assertEqual(sub(4, 3, 1), 0, 'subtracting three and one from four')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The following change allows use of sub like
```py
sub(5, 4, 1) #0
```
